### PR TITLE
add z-index to prevent wrong positioning of elements especially in Safari

### DIFF
--- a/dist/leaflet.fullscreen.css
+++ b/dist/leaflet.fullscreen.css
@@ -9,7 +9,7 @@
     height: 100% !important;
     top: 0px !important;
     left: 0px !important;
-	z-index:99999;
+    z-index:99999;
 }
 
 .leaflet-control-fullscreen a {

--- a/dist/leaflet.fullscreen.css
+++ b/dist/leaflet.fullscreen.css
@@ -9,6 +9,7 @@
     height: 100% !important;
     top: 0px !important;
     left: 0px !important;
+	z-index:99999;
 }
 
 .leaflet-control-fullscreen a {


### PR DESCRIPTION
I implemented your fullscreen plugin here: http://pro.mapsmarker.com/?p=11
For firefox, IE + Chrome this works fine - with Safari nethertheless some objects "shine through the fullscreen map" (see image attached). Fixed this by addint z-index.

![mapbox-fullscreen-zindex-issue-safari](https://f.cloud.github.com/assets/158669/272275/d670d0a2-8ffe-11e2-9fc8-2e2bf6055ff4.jpg)
