### PR TITLE
Add leaflet-bar-part-bottom to link

### DIFF
--- a/dist/leaflet.fullscreen.css
+++ b/dist/leaflet.fullscreen.css
@@ -9,7 +9,7 @@
     height: 100% !important;
     top: 0px !important;
     left: 0px !important;
-	z-index:99999;
+    z-index:99999;
 }
 
 .leaflet-control-fullscreen a {

--- a/dist/leaflet.fullscreen.css
+++ b/dist/leaflet.fullscreen.css
@@ -9,6 +9,7 @@
     height: 100% !important;
     top: 0px !important;
     left: 0px !important;
+	z-index:99999;
 }
 
 .leaflet-control-fullscreen a {

--- a/src/Leaflet.fullscreen.js
+++ b/src/Leaflet.fullscreen.js
@@ -6,7 +6,7 @@ L.Control.Fullscreen = L.Control.extend({
 
     onAdd: function (map) {
         var container = L.DomUtil.create('div', 'leaflet-control-fullscreen leaflet-bar leaflet-control'),
-            link = L.DomUtil.create('a', 'leaflet-control-fullscreen-button leaflet-bar-part', container);
+            link = L.DomUtil.create('a', 'leaflet-control-fullscreen-button leaflet-bar-part leaflet-bar-part-bottom', container);
 
         this._map = map;
 


### PR DESCRIPTION
removes the shadow from the button - try zooming to max in browser to see the difference first (as I am not sure if this is the best solution - in Android, my demo page http://pro.mapsmarker.com has no round corners on top for example...)
