### PR TITLE
MapBox CSS dark theme compatibility and JS syntax error fix

### DIFF
--- a/src/Leaflet.fullscreen.js
+++ b/src/Leaflet.fullscreen.js
@@ -2,8 +2,8 @@ L.Control.Fullscreen = L.Control.extend({
     options: {
         position: 'topleft',
         title: {
-            false: 'View Fullscreen',
-            true: 'Exit Fullscreen'
+            'false': 'View Fullscreen',
+            'true': 'Exit Fullscreen'
         }
     },
 

--- a/src/leaflet.fullscreen.css
+++ b/src/leaflet.fullscreen.css
@@ -1,6 +1,8 @@
 .leaflet-control-fullscreen a {
-  background:#fff url(fullscreen.png) no-repeat 0 0;
+  background-image:url(fullscreen.png);
   background-size:26px 52px;
+  background-position:0px 0px;
+  background-repeat:no-repeat;
   }
   .leaflet-fullscreen-on .leaflet-control-fullscreen a {
     background-position:0 -26px;


### PR DESCRIPTION
Eclipse JavaScript compiler / editor is reporting a syntax error in control's JS file. Fixed.

Explicitly setting control's background color breaks compatibility with easily switching to MapBox dark theme. Fixed by setting / overriding only background image properties.
