### PR TITLE
Added IE11 native fullscreen support

### DIFF
--- a/src/Leaflet.fullscreen.js
+++ b/src/Leaflet.fullscreen.js
@@ -47,6 +47,8 @@ L.Map.include({
                 document.mozCancelFullScreen();
             } else if (document.webkitCancelFullScreen) {
                 document.webkitCancelFullScreen();
+			} else if (document.msExitFullscreen) {
+                document.msExitFullscreen();
             } else {
                 L.DomUtil.removeClass(container, 'leaflet-pseudo-fullscreen');
                 this._toggleFullscreenClass();
@@ -61,6 +63,9 @@ L.Map.include({
                 container.mozRequestFullScreen();
             } else if (container.webkitRequestFullscreen) {
                 container.webkitRequestFullscreen(Element.ALLOW_KEYBOARD_INPUT);
+			} else if (container.msRequestFullscreen) {
+				//Messes up the popup content when viewing in an iframe
+                container.msRequestFullscreen();
             } else {
                 L.DomUtil.addClass(container, 'leaflet-pseudo-fullscreen');
                 this._toggleFullscreenClass();
@@ -84,7 +89,8 @@ L.Map.include({
         var fullscreenElement =
             document.fullscreenElement ||
             document.mozFullScreenElement ||
-            document.webkitFullscreenElement;
+            document.webkitFullscreenElement ||
+			document.msFullscreenElement;
 
         this._toggleFullscreenClass();
         if (fullscreenElement === this.getContainer()) {
@@ -115,6 +121,8 @@ L.Map.addInitHook(function () {
         fullscreenchange = 'mozfullscreenchange';
     } else if ('onwebkitfullscreenchange' in document) {
         fullscreenchange = 'webkitfullscreenchange';
+    } else if ('onmsfullscreenchange' in document) {
+        fullscreenchange = 'MSFullscreenChange';
     }
 
     if (fullscreenchange) {

--- a/src/Leaflet.fullscreen.js
+++ b/src/Leaflet.fullscreen.js
@@ -47,7 +47,7 @@ L.Map.include({
                 document.mozCancelFullScreen();
             } else if (document.webkitCancelFullScreen) {
                 document.webkitCancelFullScreen();
-			} else if (document.msExitFullscreen) {
+            } else if (document.msExitFullscreen) {
                 document.msExitFullscreen();
             } else {
                 L.DomUtil.removeClass(container, 'leaflet-pseudo-fullscreen');
@@ -63,8 +63,7 @@ L.Map.include({
                 container.mozRequestFullScreen();
             } else if (container.webkitRequestFullscreen) {
                 container.webkitRequestFullscreen(Element.ALLOW_KEYBOARD_INPUT);
-			} else if (container.msRequestFullscreen) {
-				//Messes up the popup content when viewing in an iframe
+            } else if (container.msRequestFullscreen) {
                 container.msRequestFullscreen();
             } else {
                 L.DomUtil.addClass(container, 'leaflet-pseudo-fullscreen');
@@ -90,7 +89,7 @@ L.Map.include({
             document.fullscreenElement ||
             document.mozFullScreenElement ||
             document.webkitFullscreenElement ||
-			document.msFullscreenElement;
+            document.msFullscreenElement;
 
         this._toggleFullscreenClass();
         if (fullscreenElement === this.getContainer()) {


### PR DESCRIPTION
There seems to be a problem with the popup content (for a marker) in IE11 when going fullscreen and leaflet inside an iframe.
The popup is not positioned directly above the marker, and the popup width is not set correctly.

For a test case, the basic example from http://leafletjs.com/ can be used together with an IFrame

``` html
<!DOCTYPE html>
<html>
    <head>

    </head>
    <body>
        <div style="height: 630px; width: 710px;">
            <iframe src="index.html" allowfullscreen="" webkitallowfullscreen="" mozallowfullscreen="" onmousewheel="false" frameborder="0" allowtransparency="true" style="height: 100%; width: 100%;"></iframe>
        </div>
    </body>
</html>
```

``` html
<!DOCTYPE html>
<html>
    <head>
        <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.css" />
        <link rel="stylesheet" href="leaflet.fullscreen/leaflet.fullscreen.css" />
        <script src="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.js"></script>
        <script src="leaflet.fullscreen/Leaflet.fullscreen.min.js"></script>
        <style>
            html, body {
                height: 100%;
            }

            #map {
                width: 100%;
                height: 100%;
            }
        </style>
    </head>
    <body>
        <div id="map" style="">

        </div>
        <script>
            // create a map in the "map" div, set the view to a given place and zoom
            var map = L.map('map', {
                fullscreenControl: true
            }).setView([51.505, -0.09], 13);

            // add an OpenStreetMap tile layer
            L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
                attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
            }).addTo(map);

            // add a marker in the given location, attach some popup content to it and open the popup
            var marker = new L.Marker([51.5, -0.09]);
            marker.addTo(map)
                .bindPopup('A pretty CSS3 popup. <br> Easily customizable.');
        </script>
    </body>
</html>
```
