### PR TITLE
Full screen not center on devices with touch screen

### DIFF
--- a/dist/leaflet.fullscreen.css
+++ b/dist/leaflet.fullscreen.css
@@ -2,15 +2,6 @@
   background:#fff url(fullscreen.png) no-repeat 0 0;
   background-size:26px 52px;
   }
-  .leaflet-touch .leaflet-control-fullscreen a {
-    background-position: 2px 2px;
-    }
-  .leaflet-fullscreen-on .leaflet-control-fullscreen a {
-    background-position:0 -26px;
-    }
-  .leaflet-touch.leaflet-fullscreen-on .leaflet-control-fullscreen a {
-    background-position: 2px -24px;
-    }
 
 /* Do not combine these two rules; IE will break. */
 .leaflet-container:-webkit-full-screen {


### PR DESCRIPTION
This fixes a bug on devices with touch screens that causes the full screen icon to be off-center.

Before: http://imgur.com/FaGVwrt
After: http://imgur.com/xgQgfYe
